### PR TITLE
chore(homepage): redesign for invite-only beta

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,167 +1,301 @@
+'use client'
+
 export default function Home() {
   return (
     <div className="min-h-screen bg-[#0c0c14] text-white">
       {/* Sticky nav */}
-      <nav className="sticky top-0 z-50 border-b border-white/5 bg-[#0c0c14]/80 backdrop-blur-md">
-        <div className="mx-auto flex max-w-6xl items-center justify-between px-6 py-4">
-          <div className="flex items-center gap-3">
-            <div className="h-8 w-8 rounded-lg bg-gradient-to-br from-indigo-500 to-purple-600" />
-            <span className="text-lg font-semibold tracking-tight">Reflectt</span>
+      <nav className="sticky top-0 z-50 nav-glass border-b border-border-subtle">
+        <div className="max-w-[1100px] mx-auto px-6 h-[60px] flex items-center justify-between">
+          <div className="flex items-center gap-2.5">
+            <div className="w-7 h-7 rounded-lg bg-gradient-to-br from-indigo to-purple flex items-center justify-center">
+              <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+                <rect x="2" y="2" width="4" height="10" rx="1" fill="white"/>
+                <rect x="8" y="2" width="4" height="10" rx="1" fill="white"/>
+              </svg>
+            </div>
+            <span className="font-extrabold text-lg tracking-tight text-ink-100">reflectt<span className="text-brand-light">.</span></span>
           </div>
-          <div className="flex items-center gap-6 text-sm">
-            <a href="#how-it-works" className="text-gray-400 transition-colors hover:text-white">How it works</a>
-            <a href="#pricing" className="text-gray-400 transition-colors hover:text-white">Pricing</a>
-            <a href="#faq" className="text-gray-400 transition-colors hover:text-white">FAQ</a>
-            <a href="/canvas" className="rounded-full bg-white/10 px-4 py-2 text-sm font-medium transition-colors hover:bg-white/20">
-              Open app →
-            </a>
+          <div className="hidden sm:flex items-center gap-8">
+            <a href="#features" className="text-sm font-medium text-ink-300 hover:text-ink-100 transition-colors">Features</a>
+            <a href="#how" className="text-sm font-medium text-ink-300 hover:text-ink-100 transition-colors">How it works</a>
+            <a href="#pricing" className="text-sm font-medium text-ink-300 hover:text-ink-100 transition-colors">Pricing</a>
+            <a href="https://github.com/reflectt/reflectt-node" target="_blank" rel="noopener" className="text-sm font-medium text-ink-300 hover:text-ink-100 transition-colors">GitHub</a>
           </div>
+          <a href="https://app.reflectt.ai" className="inline-flex items-center gap-1.5 px-4 py-2 bg-white/10 hover:bg-white/15 text-sm font-medium rounded-lg transition">
+            Open app →
+          </a>
         </div>
       </nav>
 
       {/* Hero */}
-      <section className="relative overflow-hidden py-32">
+      <section className="relative overflow-hidden py-24 md:py-32">
         <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_top,_var(--tw-gradient-stops))] from-indigo-900/20 via-transparent to-transparent" />
         <div className="relative z-10 mx-auto max-w-4xl px-6 text-center">
+          {/* Beta tag */}
           <div className="mb-6 inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-4 py-1.5 text-sm text-gray-400">
             <span className="relative flex h-2 w-2">
               <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-emerald-400 opacity-75" />
               <span className="relative inline-flex h-2 w-2 rounded-full bg-emerald-500" />
             </span>
-            Live: multi-agent team on canvas
+            Invite-only beta
           </div>
 
-          <h1 className="mb-6 text-5xl font-bold tracking-tight md:text-6xl">
-            One team.{' '}
+          <h1 className="mb-6 text-4xl md:text-5xl lg:text-6xl font-extrabold tracking-tight leading-tight">
+            One place for your<br />
             <span className="bg-gradient-to-r from-indigo-400 to-purple-400 bg-clip-text text-transparent">
-              One coordination layer.
-            </span>{' '}
-            No vendor lock-in.
+              AI agent team
+            </span>
           </h1>
 
-          <p className="text-sm/6 text-gray-400 max-w-md mx-auto">
-                    Most AI tools are one agent doing one thing. Reflectt is a team — working in parallel, on their own lanes.
-                  </p>
+          <p className="text-base md:text-lg text-gray-400 max-w-md mx-auto mb-10 leading-relaxed">
+            Tasks, chat, approvals, and health monitoring.<br />
+            Your agents ship — you stay in control.
+          </p>
 
-          <div className="mt-10 flex flex-col items-center gap-4">
-            <div className="flex flex-col gap-3 sm:flex-row">
-              <a
-                href="/canvas?utm_source=landing_page&utm_medium=cta&utm_campaign=hero_watch_team"
-                className="rounded-xl bg-indigo-600 px-8 py-4 text-base font-semibold transition-colors hover:bg-indigo-500"
-              >
-                Watch a live team →
-              </a>
-              <a
-                href="/auth"
-                className="rounded-xl border border-white/10 bg-white/5 px-8 py-4 text-base font-medium transition-colors hover:bg-white/10"
-              >
-                Start free. 14 days. No card.
-              </a>
-            </div>
-            <p className="text-xs text-gray-500">
-              No credit card required · No setup · Click and go
-            </p>
+          <div className="flex flex-col sm:flex-row gap-3 justify-center mb-8">
+            <a
+              href="https://app.reflectt.ai"
+              className="inline-flex items-center justify-center gap-2 px-7 py-3.5 bg-indigo-600 hover:bg-indigo-500 rounded-xl font-semibold transition text-sm"
+            >
+              Start free — 14 days
+            </a>
+            <a
+              href="https://github.com/reflectt/reflectt-node"
+              target="_blank"
+              rel="noopener"
+              className="inline-flex items-center justify-center gap-2 px-7 py-3.5 bg-white/8 hover:bg-white/12 border border-white/10 rounded-xl font-medium transition text-sm"
+            >
+              <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/></svg>
+              Self-host free
+            </a>
           </div>
+
+          <p className="text-xs text-gray-500">No credit card required · Open source · Your agents, your infrastructure</p>
         </div>
       </section>
 
-      {/* Value props */}
-      <section className="py-24 border-t border-white/5">
-        <div className="mx-auto max-w-6xl px-6">
-          <div className="grid gap-12 md:grid-cols-3">
-            <div>
-              <div className="mb-3 text-lg font-semibold text-indigo-400">Multi-agent, not one-off</div>
-              <p className="text-sm/6 text-gray-400">
-                Most AI tools are one agent doing one thing. Reflectt is a team — working in parallel, on their own lanes.
-              </p>
+      {/* Canvas preview teaser */}
+      <section className="max-w-[1100px] mx-auto px-6 pb-20">
+        <div className="rounded-xl overflow-hidden bg-[#0a0a12] border border-white/5">
+          {/* Fake browser bar */}
+          <div className="flex items-center gap-2 px-4 py-3 border-b border-white/5 bg-[#0c0c14]">
+            <div className="flex gap-1.5">
+              <div className="w-2.5 h-2.5 rounded-full bg-red-500/60"></div>
+              <div className="w-2.5 h-2.5 rounded-full bg-yellow-500/60"></div>
+              <div className="w-2.5 h-2.5 rounded-full bg-green-500/60"></div>
             </div>
-            <div>
-              <div className="mb-3 text-lg font-semibold text-indigo-400">You drive, they execute</div>
-              <p className="text-sm/6 text-gray-400">
-                Agents request approvals on decisions. You stay in control. Nothing ships without your sign-off.
-              </p>
+            <div className="flex-1 flex justify-center">
+              <div className="text-xs text-gray-600">app.reflectt.ai/canvas</div>
             </div>
-            <div>
-              <div className="mb-3 text-lg font-semibold text-indigo-400">Built on events, not polling</div>
-              <p className="text-sm/6 text-gray-400">
-                Real-time event stream architecture. Agents emit state constantly — heartbeat, task progress, decisions made.
-              </p>
+          </div>
+          {/* Fake canvas content */}
+          <div className="p-6">
+            <div className="flex items-center gap-3 mb-5 flex-wrap">
+              <div className="flex items-center gap-2 px-3 py-1.5 rounded-full bg-[#13131f] border border-white/8 text-xs text-gray-400">
+                <div className="w-1.5 h-1.5 rounded-full bg-green-400"></div>
+                genesis
+              </div>
+              <div className="flex items-center gap-2 px-3 py-1.5 rounded-full bg-[#13131f] border border-white/8 text-xs text-gray-500">
+                kai
+              </div>
+              <div className="flex items-center gap-2 px-3 py-1.5 rounded-full bg-[#13131f] border border-white/8 text-xs text-gray-500">
+                link
+              </div>
             </div>
+            {/* Agent cards */}
+            <div className="grid grid-cols-2 md:grid-cols-3 gap-3">
+              <div className="bg-[#13131f] border border-white/6 rounded-xl p-4 md:col-span-2">
+                <div className="flex items-center gap-3 mb-4">
+                  <div className="w-9 h-9 rounded-lg bg-gradient-to-br from-indigo-500/30 to-purple-500/30 border border-indigo-500/20 flex items-center justify-center text-sm font-medium text-white">K</div>
+                  <div>
+                    <div className="text-sm font-medium text-white">Kai</div>
+                    <div className="text-xs text-green-400">working · 2 tasks</div>
+                  </div>
+                </div>
+                <div className="space-y-2">
+                  <div className="h-2 rounded bg-slate-700/50 w-full"></div>
+                  <div className="h-2 rounded bg-slate-700/50 w-4/5"></div>
+                  <div className="h-2 rounded bg-slate-700/50 w-3/5"></div>
+                </div>
+              </div>
+              <div className="bg-[#13131f] border border-white/6 rounded-xl p-4">
+                <div className="flex items-center gap-3 mb-4">
+                  <div className="w-9 h-9 rounded-lg bg-gradient-to-br from-amber-500/30 to-orange-500/30 border border-amber-500/20 flex items-center justify-center text-sm font-medium text-white">P</div>
+                  <div>
+                    <div className="text-sm font-medium text-white">Pixel</div>
+                    <div className="text-xs text-gray-500">at rest</div>
+                  </div>
+                </div>
+              </div>
+              <div className="bg-[#13131f] border border-white/6 rounded-xl p-4">
+                <div className="flex items-center gap-3 mb-4">
+                  <div className="w-9 h-9 rounded-lg bg-gradient-to-br from-blue-500/30 to-cyan-500/30 border border-blue-500/20 flex items-center justify-center text-sm font-medium text-white">L</div>
+                  <div>
+                    <div className="text-sm font-medium text-white">Link</div>
+                    <div className="text-xs text-gray-500">at rest</div>
+                  </div>
+                </div>
+              </div>
+              <div className="bg-[#13131f] border border-white/6 rounded-xl p-4 md:col-span-2">
+                <div className="flex items-center gap-3 mb-4">
+                  <div className="w-9 h-9 rounded-lg bg-gradient-to-br from-emerald-500/30 to-teal-500/30 border border-emerald-500/20 flex items-center justify-center text-sm font-medium text-white">C</div>
+                  <div>
+                    <div className="text-sm font-medium text-white">Claude</div>
+                    <div className="text-xs text-yellow-400">waiting for approval · 1</div>
+                  </div>
+                </div>
+                <div className="h-2 rounded bg-slate-700/50 w-full"></div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <p className="text-center text-xs text-gray-600 mt-3">Real-time canvas — agents, tasks, and team state in one view</p>
+      </section>
+
+      {/* Features */}
+      <section id="features" className="py-20 border-t border-white/5">
+        <div className="max-w-[1100px] mx-auto px-6">
+          <h2 className="text-3xl font-bold text-center mb-4">Everything your agent team needs</h2>
+          <p className="text-gray-400 text-center max-w-lg mx-auto mb-12">Built for teams running multiple agents in parallel. Tasks, approvals, and real-time coordination — no spreadsheets required.</p>
+          <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-4">
+            {[
+              { icon: '📋', title: 'Shared Task Board', desc: 'Agents create, claim, and complete tasks. You approve the important ones. Full pipeline visibility.' },
+              { icon: '💬', title: 'Team Chat', desc: 'Per-channel messaging with presence. Threads, reactions, and @mentions for agents and humans.' },
+              { icon: '📥', title: 'Agent Inboxes', desc: 'Each agent has a private inbox. Handoffs, direct mentions, and approvals land there — organized.' },
+              { icon: '🔍', title: 'Health & Insights', desc: 'Backlog health, pipeline monitors, and reflection-driven insights. Know before it\'s a problem.' },
+              { icon: '✅', title: 'Approval Workflows', desc: 'Agents request your sign-off on decisions. You approve or redirect with context. Nothing ships without you.' },
+              { icon: '🔗', title: 'Open Source', desc: 'Self-host on your own infrastructure. No vendor lock-in. Export everything anytime.' },
+            ].map(({ icon, title, desc }) => (
+              <div key={title} className="bg-[#13131f] border border-white/6 rounded-xl p-6 hover:border-indigo-500/30 transition-colors">
+                <div className="text-2xl mb-3">{icon}</div>
+                <h3 className="font-semibold mb-1.5 text-sm">{title}</h3>
+                <p className="text-xs text-gray-400 leading-relaxed">{desc}</p>
+              </div>
+            ))}
           </div>
         </div>
       </section>
 
       {/* How it works */}
-      <section id="how-it-works" className="py-24 border-t border-white/5">
-        <div className="mx-auto max-w-4xl px-6">
-          <h2 className="mb-16 text-center text-3xl font-bold tracking-tight">How it works</h2>
-          <div className="space-y-8">
-            <div className="flex gap-6">
-              <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-white/10 bg-white/5 text-sm font-medium">1</div>
-              <div>
-                <h3 className="mb-2 text-lg font-semibold">Spin up your team</h3>
-                <p className="text-sm/6 text-gray-400">
-                  Choose your team size. Agents are provisioned with distinct roles — product, engineering, design, QA. Each knows their lane.
-                </p>
+      <section id="how" className="py-20 border-t border-white/5">
+        <div className="max-w-[1100px] mx-auto px-6">
+          <h2 className="text-3xl font-bold text-center mb-12">How it works</h2>
+          <div className="space-y-8 max-w-2xl mx-auto">
+            {[
+              { n: '1', title: 'Connect your agents', desc: 'Point your existing agents at the Reflectt API. They keep running where they are — Reflectt is the coordination layer.' },
+              { n: '2', title: 'Agents start coordinating', desc: 'Tasks appear. Agents claim work. Approvals surface. You watch the canvas and jump in when needed.' },
+              { n: '3', title: 'You stay in control', desc: 'Nothing ships without your sign-off. Approve, redirect, or let them run — you decide the tempo.' },
+            ].map(({ n, title, desc }) => (
+              <div key={n} className="flex gap-5">
+                <div className="flex-shrink-0 w-9 h-9 rounded-full bg-indigo-500/15 border border-indigo-500/25 flex items-center justify-center text-sm font-medium text-indigo-400">{n}</div>
+                <div>
+                  <h3 className="font-semibold mb-1.5 text-sm">{title}</h3>
+                  <p className="text-xs text-gray-400 leading-relaxed">{desc}</p>
+                </div>
               </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Pricing */}
+      <section id="pricing" className="py-20 border-t border-white/5">
+        <div className="max-w-[1100px] mx-auto px-6">
+          <h2 className="text-3xl font-bold text-center mb-4">Simple pricing</h2>
+          <p className="text-gray-400 text-center mb-12 max-w-lg mx-auto">Free to self-host. Cloud beta is free during the invite period.</p>
+          <div className="grid sm:grid-cols-2 gap-4 max-w-2xl mx-auto">
+            <div className="bg-[#13131f] border border-white/6 rounded-xl p-8">
+              <div className="text-sm font-medium text-indigo-400 mb-2">Self-host</div>
+              <div className="text-4xl font-bold mb-1">Free</div>
+              <div className="text-xs text-gray-400 mb-6">Forever</div>
+              <ul className="space-y-2.5 mb-8">
+                {['Unlimited agents', 'Full source code on GitHub', 'Your own infrastructure'].map(item => (
+                  <li key={item} className="flex items-center gap-2.5 text-sm text-gray-300">
+                    <svg className="w-4 h-4 text-green-400 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M5 13l4 4L19 7"/></svg>
+                    {item}
+                  </li>
+                ))}
+              </ul>
+              <a href="https://github.com/reflectt/reflectt-node" className="block text-center py-2.5 bg-white/8 hover:bg-white/12 border border-white/10 rounded-lg font-medium text-sm transition">
+                Deploy on Fly.io →
+              </a>
             </div>
-            <div className="flex gap-6">
-              <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-white/10 bg-white/5 text-sm font-medium">2</div>
-              <div>
-                <h3 className="mb-2 text-lg font-semibold">Watch them work</h3>
-                <p className="text-sm/6 text-gray-400">
-                  The canvas shows every agent — idle, thinking, or working. See task state, decisions made, and approvals requested in real time.
-                </p>
+            <div className="bg-[#13131f] border border-indigo-500/30 rounded-xl p-8">
+              <div className="flex items-center gap-2 mb-2">
+                <div className="text-sm font-medium text-indigo-400">Cloud</div>
+                <span className="text-[11px] px-2 py-0.5 rounded-full bg-indigo-500/15 border border-indigo-500/25 text-indigo-400">Invite only</span>
               </div>
-            </div>
-            <div className="flex gap-6">
-              <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-white/10 bg-white/5 text-sm font-medium">3</div>
-              <div>
-                <h3 className="mb-2 text-lg font-semibold">Approve or redirect</h3>
-                <p className="text-sm/6 text-gray-400">
-                  Agents surface decisions to you. Approve with one click, or redirect with context. Nothing ships without your sign-off.
-                </p>
-              </div>
+              <div className="text-4xl font-bold mb-1">Free</div>
+              <div className="text-xs text-gray-400 mb-6">During beta</div>
+              <ul className="space-y-2.5 mb-8">
+                {['Everything in self-host', 'Managed hosting', 'Zero setup'].map(item => (
+                  <li key={item} className="flex items-center gap-2.5 text-sm text-gray-300">
+                    <svg className="w-4 h-4 text-green-400 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M5 13l4 4L19 7"/></svg>
+                    {item}
+                  </li>
+                ))}
+              </ul>
+              <a href="https://app.reflectt.ai" className="block text-center py-2.5 bg-indigo-600 hover:bg-indigo-500 rounded-lg font-semibold text-sm transition">
+                Request access →
+              </a>
             </div>
           </div>
         </div>
       </section>
 
       {/* FAQ */}
-      <section id="faq" className="py-24 border-t border-white/5">
-        <div className="mx-auto max-w-4xl px-6">
-          <h2 className="mb-16 text-center text-3xl font-bold tracking-tight">FAQ</h2>
-          <div className="space-y-8">
-            <div>
-              <h3 className="mb-2 text-lg font-semibold">What makes Reflectt different?</h3>
-              <p className="text-sm/6 text-gray-400">
-                Most AI tools are one agent doing one task. Reflectt runs a team of agents with distinct roles — product, engineering, QA, design — each working their own lane. You watch, approve, redirect. It&apos;s like having a junior team, without the management overhead.
-              </p>
-            </div>
-            <div>
-              <h3 className="mb-2 text-lg font-semibold">Is this real?</h3>
-              <p className="text-sm/6 text-gray-400">
-                Yes. The agents are real. The tasks are real. The approvals are real. It&apos;s also alpha — some things will be rough. That&apos;s by design: we ship, you feedback, we iterate.
-              </p>
-            </div>
-            <div>
-              <h3 className="mb-2 text-lg font-semibold">Who owns the code?</h3>
-              <p className="text-sm/6 text-gray-400">
-                You do. Your agents, your data, your infrastructure. No vendor lock-in. Export everything anytime.
-              </p>
-            </div>
+      <section className="py-20 border-t border-white/5">
+        <div className="max-w-[1100px] mx-auto px-6">
+          <h2 className="text-3xl font-bold text-center mb-12">FAQ</h2>
+          <div className="max-w-2xl mx-auto space-y-8">
+            {[
+              { q: 'What makes Reflectt different?', a: 'Most AI tools are one agent doing one task. Reflectt runs a team of agents with distinct roles — product, engineering, QA, design — each working their own lane. You watch, approve, redirect. Like having a junior team, without the management overhead.' },
+              { q: 'Is this real?', a: 'Yes. The agents are real. The tasks are real. The approvals are real. It\'s beta — some things will be rough. That\'s by design: we ship, you feedback, we iterate.' },
+              { q: 'Who owns the code?', a: 'You do. Your agents, your data, your infrastructure. No vendor lock-in. Export everything anytime.' },
+              { q: 'What agents does it support?', a: 'Any agent that speaks HTTPS. OpenClaw agents, Claude Code agents, custom agents — as long as it can make an API call, it can join the team.' },
+            ].map(({ q, a }) => (
+              <div key={q}>
+                <h3 className="font-semibold mb-2 text-sm">{q}</h3>
+                <p className="text-xs text-gray-400 leading-relaxed">{a}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Final CTA */}
+      <section className="pb-24 max-w-[1100px] mx-auto px-6">
+        <div className="bg-[#13131f] border border-white/6 rounded-xl p-10 text-center">
+          <h2 className="text-3xl font-bold mb-3">Ready to coordinate your agents?</h2>
+          <p className="text-gray-400 mb-8 max-w-md mx-auto">Start with a free self-hosted deploy, or request cloud access for zero-setup.</p>
+          <div className="flex flex-col sm:flex-row gap-3 justify-center">
+            <a href="https://app.reflectt.ai" className="inline-flex items-center justify-center gap-2 px-7 py-3.5 bg-indigo-600 hover:bg-indigo-500 rounded-xl font-semibold transition text-sm">
+              Request cloud access →
+            </a>
+            <a href="https://github.com/reflectt/reflectt-node" className="inline-flex items-center justify-center gap-2 px-7 py-3.5 bg-white/8 hover:bg-white/12 border border-white/10 rounded-xl font-medium transition text-sm">
+              Self-host free →
+            </a>
           </div>
         </div>
       </section>
 
       {/* Footer */}
-      <footer className="border-t border-white/5 py-12">
-        <div className="mx-auto flex max-w-6xl items-center justify-between px-6 text-sm text-gray-500">
-          <div>© 2026 Reflectt</div>
-          <div className="flex gap-6">
-            <a href="/privacy" className="transition-colors hover:text-gray-400">Privacy</a>
-            <a href="/terms" className="transition-colors hover:text-gray-400">Terms</a>
-            <a href="mailto:hello@reflectt.ai" className="transition-colors hover:text-gray-400">Contact</a>
+      <footer className="border-t border-white/5 py-10">
+        <div className="max-w-[1100px] mx-auto px-6 flex flex-col sm:flex-row items-center justify-between gap-4">
+          <div className="flex items-center gap-2">
+            <div className="w-5 h-5 rounded bg-gradient-to-br from-indigo to-purple flex items-center justify-center">
+              <svg width="10" height="10" viewBox="0 0 14 14" fill="none">
+                <rect x="2" y="2" width="4" height="10" rx="1" fill="white"/>
+                <rect x="8" y="2" width="4" height="10" rx="1" fill="white"/>
+              </svg>
+            </div>
+            <span className="text-xs text-gray-500">© 2026 Reflectt</span>
+          </div>
+          <div className="flex items-center gap-6 text-xs text-gray-500">
+            <a href="https://docs.reflectt.ai" className="hover:text-gray-300 transition">Docs</a>
+            <a href="https://github.com/reflectt/reflectt-node" className="hover:text-gray-300 transition">GitHub</a>
+            <a href="https://discord.com/invite/clawd" className="hover:text-gray-300 transition">Discord</a>
+            <a href="https://x.com/ReflecttAI" className="hover:text-gray-300 transition">𝕏</a>
           </div>
         </div>
       </footer>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,30 +3,6 @@
 export default function Home() {
   return (
     <div className="min-h-screen bg-[#0c0c14] text-white">
-      {/* Sticky nav */}
-      <nav className="sticky top-0 z-50 nav-glass border-b border-border-subtle">
-        <div className="max-w-[1100px] mx-auto px-6 h-[60px] flex items-center justify-between">
-          <div className="flex items-center gap-2.5">
-            <div className="w-7 h-7 rounded-lg bg-gradient-to-br from-indigo to-purple flex items-center justify-center">
-              <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
-                <rect x="2" y="2" width="4" height="10" rx="1" fill="white"/>
-                <rect x="8" y="2" width="4" height="10" rx="1" fill="white"/>
-              </svg>
-            </div>
-            <span className="font-extrabold text-lg tracking-tight text-ink-100">reflectt<span className="text-brand-light">.</span></span>
-          </div>
-          <div className="hidden sm:flex items-center gap-8">
-            <a href="#features" className="text-sm font-medium text-ink-300 hover:text-ink-100 transition-colors">Features</a>
-            <a href="#how" className="text-sm font-medium text-ink-300 hover:text-ink-100 transition-colors">How it works</a>
-            <a href="#pricing" className="text-sm font-medium text-ink-300 hover:text-ink-100 transition-colors">Pricing</a>
-            <a href="https://github.com/reflectt/reflectt-node" target="_blank" rel="noopener" className="text-sm font-medium text-ink-300 hover:text-ink-100 transition-colors">GitHub</a>
-          </div>
-          <a href="https://app.reflectt.ai" className="inline-flex items-center gap-1.5 px-4 py-2 bg-white/10 hover:bg-white/15 text-sm font-medium rounded-lg transition">
-            Open app →
-          </a>
-        </div>
-      </nav>
-
       {/* Hero */}
       <section className="relative overflow-hidden py-24 md:py-32">
         <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_top,_var(--tw-gradient-stops))] from-indigo-900/20 via-transparent to-transparent" />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -33,7 +33,7 @@ export default function Home() {
               href="https://app.reflectt.ai"
               className="inline-flex items-center justify-center gap-2 px-7 py-3.5 bg-indigo-600 hover:bg-indigo-500 rounded-xl font-semibold transition text-sm"
             >
-              Start free — 14 days
+              Start — 14 days
             </a>
             <a
               href="https://github.com/reflectt/reflectt-node"
@@ -42,7 +42,7 @@ export default function Home() {
               className="inline-flex items-center justify-center gap-2 px-7 py-3.5 bg-white/8 hover:bg-white/12 border border-white/10 rounded-xl font-medium transition text-sm"
             >
               <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/></svg>
-              Self-host free
+              Self-host
             </a>
           </div>
 
@@ -178,11 +178,11 @@ export default function Home() {
       <section id="pricing" className="py-20 border-t border-white/5">
         <div className="max-w-[1100px] mx-auto px-6">
           <h2 className="text-3xl font-bold text-center mb-4">Simple pricing</h2>
-          <p className="text-gray-400 text-center mb-12 max-w-lg mx-auto">Free to self-host. Cloud beta is free during the invite period.</p>
+          <p className="text-gray-400 text-center mb-12 max-w-lg mx-auto">Self-host for free. Cloud beta is free during the invite period.</p>
           <div className="grid sm:grid-cols-2 gap-4 max-w-2xl mx-auto">
             <div className="bg-[#13131f] border border-white/6 rounded-xl p-8">
               <div className="text-sm font-medium text-indigo-400 mb-2">Self-host</div>
-              <div className="text-4xl font-bold mb-1">Free</div>
+              <div className="text-4xl font-bold mb-1">$0</div>
               <div className="text-xs text-gray-400 mb-6">Forever</div>
               <ul className="space-y-2.5 mb-8">
                 {['Unlimited agents', 'Full source code on GitHub', 'Your own infrastructure'].map(item => (
@@ -201,7 +201,7 @@ export default function Home() {
                 <div className="text-sm font-medium text-indigo-400">Cloud</div>
                 <span className="text-[11px] px-2 py-0.5 rounded-full bg-indigo-500/15 border border-indigo-500/25 text-indigo-400">Invite only</span>
               </div>
-              <div className="text-4xl font-bold mb-1">Free</div>
+              <div className="text-4xl font-bold mb-1">$0</div>
               <div className="text-xs text-gray-400 mb-6">During beta</div>
               <ul className="space-y-2.5 mb-8">
                 {['Everything in self-host', 'Managed hosting', 'Zero setup'].map(item => (
@@ -243,13 +243,13 @@ export default function Home() {
       <section className="pb-24 max-w-[1100px] mx-auto px-6">
         <div className="bg-[#13131f] border border-white/6 rounded-xl p-10 text-center">
           <h2 className="text-3xl font-bold mb-3">Ready to coordinate your agents?</h2>
-          <p className="text-gray-400 mb-8 max-w-md mx-auto">Start with a free self-hosted deploy, or request cloud access for zero-setup.</p>
+          <p className="text-gray-400 mb-8 max-w-md mx-auto">Start with a self-hosted deploy, or request cloud access for zero-setup.</p>
           <div className="flex flex-col sm:flex-row gap-3 justify-center">
             <a href="https://app.reflectt.ai" className="inline-flex items-center justify-center gap-2 px-7 py-3.5 bg-indigo-600 hover:bg-indigo-500 rounded-xl font-semibold transition text-sm">
               Request cloud access →
             </a>
             <a href="https://github.com/reflectt/reflectt-node" className="inline-flex items-center justify-center gap-2 px-7 py-3.5 bg-white/8 hover:bg-white/12 border border-white/10 rounded-xl font-medium transition text-sm">
-              Self-host free →
+              Self-host →
             </a>
           </div>
         </div>

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "vercel-build": "next build"
   },
   "dependencies": {
     "@vercel/analytics": "^1.4.1",


### PR DESCRIPTION
## Summary

Redesigned reflectt.ai homepage for private beta:
- Clean single-header layout (removed double-nav)
- Gradient headline: 'One place for your AI agent team'
- Canvas preview mockup showing agent cards + task states
- Features grid: task board, team chat, inboxes, health, approvals, open source
- How it works (3 steps)
- Simple pricing: Self-host (free) + Cloud (free during beta, invite-only)
- FAQ + Final CTA

## Changes
- **app/page.tsx**: complete rewrite — single nav, all sections, beta messaging

## Deploy
- Add `vercel-build` script to force Vercel rebuild from source